### PR TITLE
embed endpoint can now return text and/or image embeddings for mllama models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ test_data
 llama/build
 __debug_bin*
 llama/vendor
+build/

--- a/api/types.go
+++ b/api/types.go
@@ -252,6 +252,8 @@ type EmbedRequest struct {
 	// Input is the input to embed.
 	Input any `json:"input"`
 
+	Images []ImageData `json:"images,omitempty"`
+
 	// KeepAlive controls how long the model will stay loaded in memory following
 	// this request.
 	KeepAlive *Duration `json:"keep_alive,omitempty"`
@@ -279,6 +281,8 @@ type EmbeddingRequest struct {
 
 	// Prompt is the textual prompt to embed.
 	Prompt string `json:"prompt"`
+
+	Images []ImageData `json:"images,omitempty"`
 
 	// KeepAlive controls how long the model will stay loaded in memory following
 	// this request.

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -772,7 +772,7 @@ func (s *mockLlm) Completion(ctx context.Context, req llm.CompletionRequest, fn 
 	return s.completionResp
 }
 
-func (s *mockLlm) Embedding(ctx context.Context, input string) ([]float32, error) {
+func (s *mockLlm) Embedding(ctx context.Context, inputtext string, inputimage []llm.ImageData) ([]float32, error) {
 	return s.embeddingResp, s.embeddingRespErr
 }
 


### PR DESCRIPTION
- Images are now passed to the `embed` endpoint in congruence with the `generate` endpoint.
- The `[img-0]` tag is now added to the text string when passing an image to the `embed` endpoint.
- `sched_test.go` has been updated to include passing of images.
- added `build/` directory to `.gitignore`